### PR TITLE
perf: add generateStaticParams for portfolio routes

### DIFF
--- a/src/app/(portfolio)/portfolio/[[...slug]]/page.tsx
+++ b/src/app/(portfolio)/portfolio/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import {
   getPhotosByCategory,
   getPhotosBySubcategory,
   getAllCategories,
+  getAllCategoriesStatic,
 } from '@/lib/api/photos';
 import { Container } from '@/components/layout/Container';
 import { PortfolioPageHero } from '@/components/features/portfolio';
@@ -15,14 +16,26 @@ import { Suspense } from 'react';
 import { Loading } from '@/components/ui/Loading';
 
 interface PortfolioPageProps {
-  // searchParams: Promise<{
-  //   category?: string;
-  //   subcategory?: string;
-  // }>;
   params:Promise<{
     slug: string[];
   }>;
 }
+
+export async function generateStaticParams() {
+  const categories = await getAllCategoriesStatic();
+
+  const paths: { slug: string[] }[] = [{ slug: [] }];
+
+  for (const category of categories ?? []) {
+    paths.push({ slug: [category.slug] });
+    for (const sub of category.subcategories ?? []) {
+      paths.push({ slug: [category.slug, sub.slug] });
+    }
+  }
+
+  return paths;
+}
+
 // Make Server Component Partial Pre-Rendered by using cacheComponents in next.config.ts
 const GalleryGridSection = async ({
   params,

--- a/src/lib/api/photos.ts
+++ b/src/lib/api/photos.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { getSupabaseStatic } from '@/lib/supabase/static';
 import type { QueryData } from '@supabase/supabase-js';
 
 const logPostgrestError = (
@@ -190,4 +191,13 @@ export async function getAllCategories() {
   }));
 
   return categoriesWithSortedSubcategories;
+}
+
+export async function getAllCategoriesStatic() {
+  const { data: categories } = await getSupabaseStatic()
+    .from('categories')
+    .select('slug, subcategories(slug)')
+    .order('display_order', { ascending: true });
+
+  return categories ?? [];
 }

--- a/src/lib/supabase/static.ts
+++ b/src/lib/supabase/static.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database.types';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!;
+let _client: ReturnType<typeof createClient<Database>> | null = null;
+
+export function getSupabaseStatic() {
+  if (!_client) {
+    const url = supabaseUrl;
+    const key = supabaseKey;
+
+    if (!url || !key) throw new Error('Missing Supabase environment variables');
+
+    _client = createClient<Database>(url, key);
+  }
+  return _client;
+}


### PR DESCRIPTION
- Pre-render all category and subcategory slug paths at build time
- Add getAllCategoriesStatic for lightweight build-time data fetching
- Add singleton Supabase client for static generation context