### PR TITLE
fix: fallback slug when no work projects exist

### DIFF
--- a/src/app/(portfolio)/work/[slug]/page.tsx
+++ b/src/app/(portfolio)/work/[slug]/page.tsx
@@ -25,6 +25,7 @@ interface WorkPageProps {
 
 export async function generateStaticParams() {
   const projects = await getAllWorkProjectSlugs();
+  if (projects.length === 0) return [{ slug: 'paria-creative-vision' }];
   return projects.map(({ slug }) => ({ slug }));
 }
 


### PR DESCRIPTION
Prevents generateStaticParams from returning an empty array, which causes Next.js to skip static generation and 404 on the work/[slug] route at build time with an empty database.