### PR TITLE
feat: add Talent Atlas section pages and reorder nav

### DIFF
--- a/src/app/(talent-atlas)/talent-atlas/(app)/campaigns/page.tsx
+++ b/src/app/(talent-atlas)/talent-atlas/(app)/campaigns/page.tsx
@@ -1,0 +1,8 @@
+export default function CampaignsPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-slate-900">Campaigns</h1>
+      <p className="mt-1 text-sm text-slate-500">Coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/(talent-atlas)/talent-atlas/(app)/candidates/page.tsx
+++ b/src/app/(talent-atlas)/talent-atlas/(app)/candidates/page.tsx
@@ -1,0 +1,8 @@
+export default function CandidatesPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-slate-900">Candidates</h1>
+      <p className="mt-1 text-sm text-slate-500">Coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/(talent-atlas)/talent-atlas/(app)/companies/page.tsx
+++ b/src/app/(talent-atlas)/talent-atlas/(app)/companies/page.tsx
@@ -1,0 +1,8 @@
+export default function CompaniesPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-slate-900">Companies</h1>
+      <p className="mt-1 text-sm text-slate-500">Coming soon.</p>
+    </div>
+  );
+}

--- a/src/components/features/talentAtlas/TalentAtlasHeader.tsx
+++ b/src/components/features/talentAtlas/TalentAtlasHeader.tsx
@@ -6,9 +6,9 @@ import { routes as ROUTE } from '@/lib/routes/routes';
 
 const navItems = [
   { label: 'Dashboard', href: ROUTE.talentAtlasDashboard },
+  { label: 'Companies', href: ROUTE.talentAtlasCompanies },
   { label: 'Candidates', href: ROUTE.talentAtlasCandidates },
   { label: 'Campaigns', href: ROUTE.talentAtlasCampaigns },
-  { label: 'Companies', href: ROUTE.talentAtlasCompanies },
   { label: 'Settings', href: ROUTE.talentAtlasSettings },
 ];
 


### PR DESCRIPTION
- Add stub pages for Campaigns, Candidates, and Companies routes
- Reorder nav items: Companies moved before Candidates